### PR TITLE
Fix cropping portrait images

### DIFF
--- a/app/utils/image_processor.py
+++ b/app/utils/image_processor.py
@@ -1,7 +1,7 @@
 import os
 import logging
 import piexif
-from PIL import Image
+from PIL import Image, ImageOps
 from config import INPUT_FOLDER, OUTPUT_FOLDER, PORTRAIT_SIZE, LANDSCAPE_SIZE
 from utils.file_handler import get_filename_from_asset_id
 
@@ -28,7 +28,9 @@ def crop_image(asset_id, orientation, crop_data):
         if not os.path.exists(img_path):
             return False, f"Image file not found: {img_path}"
 
+        # Open the image and apply EXIF orientation
         img = Image.open(img_path)
+        img = ImageOps.exif_transpose(img)
 
         # Extract crop coordinates
         x = int(crop_data["x"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flask==3.1.0
-pillow==11.2.0
+pillow==11.2.1
 pillow-heif==0.22.0
 requests==2.32.3
 PyYAML==6.0.2


### PR DESCRIPTION
Fix issue where portrait images get cut in the wrong orientation as pillow doesn't rotate the image to EXIF orientation by default.
This produces correct crops with both my phone and camera in both orientations.

Also had to bump pillow version as 11.2.0 was removed (https://pillow.readthedocs.io/en/stable/releasenotes/11.2.1.html).

PS. Thanks, this is great :+1: